### PR TITLE
switched to a more robust method of patching Monaco's syntax highlighting

### DIFF
--- a/packages/record-tuple-playground/src/index.jsx
+++ b/packages/record-tuple-playground/src/index.jsx
@@ -14,10 +14,9 @@
  ** limitations under the License.
  */
 
-import { patch, patchLanguage } from "./patch";
+import "./patch";
 import "regenerator-runtime/runtime";
-patch();
-patchLanguage();
+
 
 import * as Babel from "@babel/core";
 import RecordAndTuple from "@bloomberg/babel-plugin-proposal-record-tuple";

--- a/packages/record-tuple-playground/src/patch.js
+++ b/packages/record-tuple-playground/src/patch.js
@@ -16,7 +16,6 @@
 
 import * as Polyfill from "@bloomberg/record-tuple-polyfill";
 import * as Monaco from "monaco-editor";
-import { LanguageConfigurationRegistry } from "monaco-editor/esm/vs/editor/common/modes/languageConfigurationRegistry";
 import { conf, language } from "./patch-language";
 
 const POLYFILL_DTS = `
@@ -47,7 +46,7 @@ export const Record: RecordConstructor;
 export const Tuple: TupleConstructor;
 `;
 
-export function patch() {
+function patch() {
     // eslint-disable-next-line no-undef
     window.MonacoEnvironment = {
         getWorkerUrl: function(moduleId, label) {
@@ -73,18 +72,13 @@ export function patch() {
     };
 }
 
-export function patchLanguage() {
-    function doPatch() {
-        console.log("patching javascript language support");
-        Monaco.languages.setLanguageConfiguration("javascript", conf);
-        Monaco.languages.setMonarchTokensProvider("javascript", language);
-    }
-
-    let patched = false;
-    LanguageConfigurationRegistry.onDidChange(() => {
-        if (!patched) {
-            patched = true;
-            doPatch();
+function patchLanguage() {
+    Monaco.languages.getLanguages().forEach(lang => {
+        if (lang.id === "typescript" || lang.id === "javascript") {
+            lang.loader = () => Promise.resolve({ conf, language });
         }
     });
 }
+
+patch();
+patchLanguage();


### PR DESCRIPTION
Signed-off-by: Richard Button <rbutton2@bloomberg.net>

**Describe your changes**
We manually patch the `monaco-editor` language registry in order to provide support for Record and Tuple syntax automatically. This is very brittle, and I have moved to a better method of patching it, which should work every time.
