### PR TITLE
add proper error message to the playground when weakrefs isn't enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Record & Tuple Polyfill
-
 The [Record and Tuple](https://github.com/tc39/proposal-record-tuple) ECMAScript proposal introduces new deeply immutable value types to JavaScript 
 that have similar access idioms to objects and arrays.
 
@@ -65,3 +64,17 @@ console.log(Tuple.from(array));
 
 `typeof` will return an incorrect value when provided a `Record` or `Tuple`. 
 This is because the polyfill implements the proposal via [interning](https://en.wikipedia.org/wiki/String_interning) frozen objects.
+
+# Playground
+
+The Record and Tuple polyfill has been deployed in an easy to use REPL [here](https://rickbutton.github.io/record-tuple-playground/).
+
+## Supported Environments/Browsers
+
+The Record and Tuple polyfill requires several JavaScript features that are only available experimentally in browsers, specifically `WeakRef` and `FinalizationRegistry`. In order to use these experimental features, you must run the browser/environment with specific flags:
+
+| environment     | flags                                    |
+|-----------------|------------------------------------------|
+| node            | --harmony-weak-refs                      |
+| Chrome          | --js-flags="--harmony-weak-refs"         |
+| Firefox Nightly | javascript.options.experimental.weakrefs |

--- a/packages/record-tuple-playground/src/index.jsx
+++ b/packages/record-tuple-playground/src/index.jsx
@@ -48,6 +48,15 @@ function debounce(func, wait, immediate) {
     };
 };
 
+const CAN_EVAL = (() => {
+    const WeakRef = globalThis["WeakRef"];
+    const FinalizationRegistry = globalThis["FinalizationRegistry"] || globalThis["FinalizationGroup"];
+    const WeakMap = globalThis["WeakMap"];
+    return WeakRef && FinalizationRegistry && WeakMap;
+})();
+const NO_EVAL_ERROR = "WeakMap, WeakRef, and FinalizationRegistry are required for the Record and Tuple playground\n\n" + 
+	"To enable these experimental features, go to:\n  https://github.com/bloomberg/record-tuple-polyfill#playground";
+
 const CONSOLE_STYLES = {
     LOG_ICON_WIDTH: "0px",
     LOG_ICON_HEIGHT: "0px",
@@ -172,8 +181,9 @@ class App extends React.Component {
             lineDecoratorsWidth: 0,
             lineNumbersMinChars: 0,
             model: undefined,
-            language: "javascript",
+            language: "plaintext",
             readOnly: true,
+            wordWrap: "on",
         });
     }
 
@@ -297,12 +307,16 @@ class App extends React.Component {
     }
 
     run() {
-        try {
-            const func = new Function("console", this.state.output);
-            func(this.fakeConsole);
-        } catch(e) {
-            this.fakeConsole.error(e.message);
-            this.fakeConsole.error(e);
+        if (CAN_EVAL) {
+            try {
+                const func = new Function("console", this.state.output);
+                func(this.fakeConsole);
+            } catch(e) {
+                this.fakeConsole.error(e.message);
+                this.fakeConsole.error(e);
+            }
+        } else {
+            this.setState({ isError: true, output: NO_EVAL_ERROR });
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Richard Button <rbutton2@bloomberg.net>

Added an additional error message to the playground that points to documentation when the environment doesn't support WeakRef.