### PR TITLE
Fix Tuple methods names (reversed, sorted, spliced, sliced)

### DIFF
--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -119,7 +119,7 @@ Tuple.prototype.popped = function popped() {
 Tuple.prototype.pushed = function pushed(...vals) {
     return createTupleFromIterableObject([...this, ...vals]);
 };
-Tuple.prototype.reverse = function reverse() {
+Tuple.prototype.reversed = function reversed() {
     return createTupleFromIterableObject(Array.from(this).reverse());
 };
 Tuple.prototype.shifted = function shifted() {
@@ -128,12 +128,12 @@ Tuple.prototype.shifted = function shifted() {
 Tuple.prototype.unshifted = function unshifted(...vals) {
     return createTupleFromIterableObject([...vals, ...this]);
 };
-Tuple.prototype.sort = function sort(compareFunction) {
+Tuple.prototype.sorted = function sorted(compareFunction) {
     return createTupleFromIterableObject(
         Array.from(this).sort(compareFunction),
     );
 };
-Tuple.prototype.splice = function splice(start, deleteCount, ...items) {
+Tuple.prototype.spliced = function spliced(start, deleteCount, ...items) {
     return createTupleFromIterableObject(
         Array.from(this).slice(start, deleteCount, ...items),
     );
@@ -153,7 +153,7 @@ Tuple.prototype.join = function join(separator) {
 Tuple.prototype.lastIndexOf = function lastIndexOf(valueToFind, fromIndex) {
     return Array.from(this).lastIndexOf(valueToFind, fromIndex);
 };
-Tuple.prototype.slice = function slice(start, end) {
+Tuple.prototype.sliced = function sliced(start, end) {
     return createTupleFromIterableObject(Array.from(this).slice(start, end));
 };
 Tuple.prototype.toLocaleString = function toLocaleString(locales, options) {

--- a/packages/record-tuple-polyfill/src/tuple.test.js
+++ b/packages/record-tuple-polyfill/src/tuple.test.js
@@ -112,6 +112,32 @@ test("Tuple.of", () => {
     expect(Tuple.of(1, 2, 3)).toBe(Tuple(1, 2, 3));
 });
 
+describe("all and only the specified prototype methods exist", () => {
+    const list = ([str]) => str.trim().split(/\s+/g);
+    const has = Function.call.bind(Object.hasOwnProperty);
+
+    // MISSING: valueOf, length, Symbol.toStringTag
+    const names = list`
+        constructor
+        popped pushed reversed shifted sliced
+        sorted spliced concat includes indexOf join
+        lastIndexOf entries every filter find findIndex
+        forEach keys map reduce reduceRight some
+        unshifted toLocaleString toString values
+    `.concat(Symbol.iterator);
+
+    test.each(names)(".%s", name => {
+        // We can't use expect().toHaveProperty because its doesn't support symbols
+        expect(has(Tuple.prototype, name)).toBe(true);
+
+        expect(Tuple.prototype[name]).toEqual(expect.any(Function));
+    });
+
+    test("no extra properties", () => {
+        expect(Object.keys(Tuple.prototype)).toHaveLength(names.length);
+    });
+});
+
 test("Tuple.prototype.toString", () => {
     expect(Tuple(1, 2, 3).toString()).toEqual("[tuple Tuple]");
 });


### PR DESCRIPTION
*Issue number of the reported bug or feature request:* Fixes #13

**Describe your changes**
Some methods had the name of the array method rather than the `...ed` name

**Testing performed**
I copied the list of expected prototype methods/properties from the proposal spec, and checked that they are defined.
This highlighted some missing methods, which will be added in a separate PR.

