### PR TITLE
Implement Tuple.prototype.length

### DIFF
--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -21,6 +21,7 @@ import {
     isTuple,
     markTuple,
     validateProperty,
+    getTupleLength,
 } from "./utils";
 
 function createFreshTupleFromIterableObject(value) {
@@ -41,15 +42,8 @@ function createFreshTupleFromIterableObject(value) {
         length++;
     }
 
-    Object.defineProperty(tuple, "length", {
-        value: length,
-        writable: false,
-        enumerable: false,
-        configurable: false,
-    });
-
     Object.freeze(tuple);
-    markTuple(tuple);
+    markTuple(tuple, length);
     return tuple;
 }
 
@@ -108,6 +102,19 @@ Tuple.isTuple = isTuple;
 Tuple.of = function of(...values) {
     return createTupleFromIterableObject(Array.of(...values));
 };
+
+Object.defineProperty(Tuple.prototype, "length", {
+    enumerable: false,
+    configurable: false,
+    get: function get_length() {
+        if (!isTuple(this)) {
+            throw new TypeError(
+                "'get Tuple.prototype.length' called on incompatible receiver.",
+            );
+        }
+        return getTupleLength(this);
+    },
+});
 
 Tuple.prototype.popped = function popped() {
     if (this.length <= 1) return Tuple();

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -48,19 +48,22 @@ export function unbox(v) {
     }
 }
 
-const RECORD_WEAKMAP = new WeakMap();
-const TUPLE_WEAKMAP = new WeakMap();
+const RECORD_WEAKSET = new WeakSet();
+const TUPLE_WEAKMAP = new WeakMap(); // tuple -> length
 export function isRecord(value) {
-    return RECORD_WEAKMAP.has(value);
+    return RECORD_WEAKSET.has(value);
 }
 export function isTuple(value) {
     return TUPLE_WEAKMAP.has(value);
 }
 export function markRecord(value) {
-    RECORD_WEAKMAP.set(value, true);
+    RECORD_WEAKSET.add(value);
 }
-export function markTuple(value) {
-    TUPLE_WEAKMAP.set(value, true);
+export function markTuple(value, length) {
+    TUPLE_WEAKMAP.set(value, length);
+}
+export function getTupleLength(value) {
+    return TUPLE_WEAKMAP.get(value);
 }
 
 function isRecordOrTuple(value) {


### PR DESCRIPTION
**Describe your changes**
`Tuple(1, 2, 3).length` was implemented as an own property, but it should be an accessor on the prototype

**Testing performed**
Tests added
