### PR TITLE
Implement Tuple prototype valueOf

### DIFF
--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -90,9 +90,6 @@ Tuple.prototype[Symbol.iterator] = function TupleIterator() {
         },
     };
 };
-Tuple.prototype.toString = function toString() {
-    return "[tuple Tuple]";
-};
 
 Tuple.from = function from(arrayLike, mapFn, thisArg) {
     return createTupleFromIterableObject(Array.from(arrayLike, mapFn, thisArg));
@@ -115,6 +112,14 @@ Object.defineProperty(Tuple.prototype, "length", {
         return getTupleLength(this);
     },
 });
+
+Tuple.prototype.toString = function toString() {
+    return "[tuple Tuple]";
+};
+
+Tuple.prototype.valueOf = function valueOf() {
+    return this;
+};
 
 Tuple.prototype.popped = function popped() {
     if (this.length <= 1) return Tuple();

--- a/packages/record-tuple-polyfill/src/tuple.test.js
+++ b/packages/record-tuple-polyfill/src/tuple.test.js
@@ -110,9 +110,9 @@ test("Tuple.of", () => {
 describe("all and only the specified prototype methods exist", () => {
     const list = ([str]) => str.trim().split(/\s+/g);
 
-    // MISSING: valueOf, length, Symbol.toStringTag
+    // MISSING: Symbol.toStringTag
     const names = list`
-        constructor
+        constructor valueOf length
         popped pushed reversed shifted sliced
         sorted spliced concat includes indexOf join
         lastIndexOf entries every filter find findIndex
@@ -124,11 +124,15 @@ describe("all and only the specified prototype methods exist", () => {
         // We can't use expect().toHaveProperty because its doesn't support symbols
         expect(hasOwn(Tuple.prototype, name)).toBe(true);
 
-        expect(Tuple.prototype[name]).toEqual(expect.any(Function));
+        if (name !== "length") {
+            expect(Tuple.prototype[name]).toEqual(expect.any(Function));
+        }
     });
 
     test("no extra properties", () => {
-        expect(Object.keys(Tuple.prototype)).toHaveLength(names.length);
+        expect(Object.getOwnPropertyNames(Tuple.prototype)).toHaveLength(
+            names.length,
+        );
     });
 });
 


### PR DESCRIPTION
**Describe your changes**
This function is completely unuseful since we cannot polyfill the difference between primitives and their object wrappers, but we should still have it for completeness.

**Testing performed**
While adding it to the list of prototype properties, I also found a bug in that test (it didn't check for non-enumerable props).
