### PR TITLE
Add records and tuples support to `JSON.stringify`

### DIFF
--- a/packages/record-tuple-polyfill/src/index.js
+++ b/packages/record-tuple-polyfill/src/index.js
@@ -14,6 +14,14 @@
  ** limitations under the License.
  */
 
+import { stringify } from "./json";
+
+const _JSON = {
+    stringify,
+    parse: JSON.parse,
+    [Symbol.toStringTag]: JSON[Symbol.toStringTag],
+};
+
+export { _JSON as JSON, stringify };
 export { Record } from "./record";
 export { Tuple } from "./tuple";
-export { stringify } from "./json";

--- a/packages/record-tuple-polyfill/src/index.js
+++ b/packages/record-tuple-polyfill/src/index.js
@@ -16,3 +16,4 @@
 
 export { Record } from "./record";
 export { Tuple } from "./tuple";
+export { stringify } from "./json";

--- a/packages/record-tuple-polyfill/src/json.js
+++ b/packages/record-tuple-polyfill/src/json.js
@@ -1,0 +1,55 @@
+/*
+ ** Copyright 2020 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+ */
+
+import { isRecord, isTuple } from "./utils";
+
+export function stringify(value, replacer, space) {
+    let props;
+    if (Array.isArray(replacer)) {
+        props = new Set();
+        replacer.forEach(v => {
+            if (
+                typeof v === "string" ||
+                typeof v === "number" ||
+                v instanceof Number ||
+                v instanceof String
+            ) {
+                props.add(String(v));
+            }
+        });
+    }
+
+    return JSON.stringify(
+        value,
+        function stringifyReplacer(key, val) {
+            if (
+                props &&
+                val !== value && // The top-level value cannot be excluded
+                !props.has(key)
+            ) {
+                return undefined;
+            }
+            if (typeof replacer === "function") {
+                val = replacer.call(this, key, val);
+            }
+
+            if (isRecord(val)) return { ...val };
+            else if (isTuple(val)) return Array.from(val);
+            return val;
+        },
+        space,
+    );
+}

--- a/packages/record-tuple-polyfill/src/json.js
+++ b/packages/record-tuple-polyfill/src/json.js
@@ -16,6 +16,8 @@
 
 import { isRecord, isTuple } from "./utils";
 
+const JSON$stringify = JSON.stringify;
+
 export function stringify(value, replacer, space) {
     let props;
     if (Array.isArray(replacer)) {
@@ -32,7 +34,7 @@ export function stringify(value, replacer, space) {
         });
     }
 
-    return JSON.stringify(
+    return JSON$stringify(
         value,
         function stringifyReplacer(key, val) {
             if (

--- a/packages/record-tuple-polyfill/src/json.js
+++ b/packages/record-tuple-polyfill/src/json.js
@@ -34,16 +34,16 @@ export function stringify(value, replacer, space) {
         });
     }
 
+    let isTopLevel = true;
+
     return JSON$stringify(
         value,
         function stringifyReplacer(key, val) {
-            if (
-                props &&
-                val !== value && // The top-level value cannot be excluded
-                !props.has(key)
-            ) {
+            if (props && !isTopLevel && !props.has(key)) {
                 return undefined;
             }
+            isTopLevel = false; // The top-level value is never excluded
+
             if (typeof replacer === "function") {
                 val = replacer.call(this, key, val);
             }

--- a/packages/record-tuple-polyfill/src/json.test.js
+++ b/packages/record-tuple-polyfill/src/json.test.js
@@ -1,0 +1,98 @@
+/*
+ ** Copyright 2020 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+ */
+
+import { Record, Tuple, stringify } from "./";
+
+describe("stringify", () => {
+    test("supports records and tuples", () => {
+        const value = Record({
+            foo: 2,
+            bar: Tuple("a", Record({}), Tuple()),
+        });
+
+        expect(stringify(value)).toBe(`{"bar":["a",{},[]],"foo":2}`);
+    });
+
+    test("supports the 'space' parameter", () => {
+        const value = Record({
+            foo: 2,
+            bar: Tuple("a", Record({}), Tuple()),
+        });
+
+        expect(stringify(value, null, 2)).toMatchInlineSnapshot(`
+        "{
+          \\"bar\\": [
+            \\"a\\",
+            {},
+            []
+          ],
+          \\"foo\\": 2
+        }"
+    `);
+
+        expect(stringify(value, null, "hello")).toMatchInlineSnapshot(`
+        "{
+        hello\\"bar\\": [
+        hellohello\\"a\\",
+        hellohello{},
+        hellohello[]
+        hello],
+        hello\\"foo\\": 2
+        }"
+    `);
+    });
+
+    test("supports the replacer array", () => {
+        const value = Record({
+            foo: 2,
+            bar: Tuple(
+                "a",
+                Record({
+                    bar: Record({ bar: 1, baz: 5 }),
+                    asd: 3,
+                    baz: 4,
+                }),
+                Tuple(),
+            ),
+        });
+
+        expect(stringify(value, ["bar", Object("baz"), 0, Object(1)])).toBe(
+            '{"bar":["a",{"bar":{"bar":1,"baz":5},"baz":4},null]}',
+        );
+    });
+
+    test("the replacer function receives records and tuples as args", () => {
+        const value = {
+            a: Record({ x: 1 }),
+            b: { y: Tuple() },
+        };
+
+        const args = [];
+
+        JSON.stringify(value, (key, value) => {
+            args.push({ key, value });
+            return value;
+        });
+
+        expect(args).toEqual([
+            { key: "", value: value },
+            { key: "a", value: Record({ x: 1 }) },
+            { key: "x", value: 1 },
+            { key: "b", value: { y: Tuple() } },
+            { key: "y", value: Tuple() },
+        ]);
+    });
+});

--- a/packages/record-tuple-polyfill/src/json.test.js
+++ b/packages/record-tuple-polyfill/src/json.test.js
@@ -103,7 +103,7 @@ describe("stringify", () => {
         obj.bar = obj;
 
         expect(stringify(obj, ["foo", 0, 1, 2])).toMatchInlineSnapshot(
-            `"{\\"foo\\":[null,null,null]}"`,
+            `"{\\"foo\\":[1,2,3]}"`,
         );
     });
 });

--- a/packages/record-tuple-polyfill/src/json.test.js
+++ b/packages/record-tuple-polyfill/src/json.test.js
@@ -33,26 +33,26 @@ describe("stringify", () => {
         });
 
         expect(stringify(value, null, 2)).toMatchInlineSnapshot(`
-        "{
-          \\"bar\\": [
-            \\"a\\",
-            {},
-            []
-          ],
-          \\"foo\\": 2
-        }"
-    `);
+                    "{
+                      \\"bar\\": [
+                        \\"a\\",
+                        {},
+                        []
+                      ],
+                      \\"foo\\": 2
+                    }"
+            `);
 
         expect(stringify(value, null, "hello")).toMatchInlineSnapshot(`
-        "{
-        hello\\"bar\\": [
-        hellohello\\"a\\",
-        hellohello{},
-        hellohello[]
-        hello],
-        hello\\"foo\\": 2
-        }"
-    `);
+                    "{
+                    hello\\"bar\\": [
+                    hellohello\\"a\\",
+                    hellohello{},
+                    hellohello[]
+                    hello],
+                    hello\\"foo\\": 2
+                    }"
+            `);
     });
 
     test("supports the replacer array", () => {
@@ -94,5 +94,16 @@ describe("stringify", () => {
             { key: "b", value: { y: Tuple() } },
             { key: "y", value: Tuple() },
         ]);
+    });
+
+    test("works with circular objects", () => {
+        const obj = {
+            foo: Tuple(1, 2, 3),
+        };
+        obj.bar = obj;
+
+        expect(stringify(obj, ["foo", 0, 1, 2])).toMatchInlineSnapshot(
+            `"{\\"foo\\":[null,null,null]}"`,
+        );
     });
 });


### PR DESCRIPTION
**Describe your changes**
This PR adds a new polyfill for `JSON.stringify`. It is exported without overwriting the native function.

**Testing performed**
Tests added. I still have to check how it behaves with circular structures.
If you want see other tests, please ask.