### PR TITLE
Fix descriptors of Record and Tuple methods

### DIFF
--- a/packages/record-tuple-polyfill/src/record.js
+++ b/packages/record-tuple-polyfill/src/record.js
@@ -21,6 +21,7 @@ import {
     validateProperty,
     isRecord,
     markRecord,
+    define,
 } from "./utils";
 
 function createFreshRecordFromProperties(properties) {
@@ -61,16 +62,23 @@ export function Record(value) {
 // ensure that Record.name is "Record" even if this
 // source is aggressively minified or bundled.
 if (Record.name !== "Record") {
-    Object.defineProperty(Record, "name", { value: "Record" });
+    Object.defineProperty(Record, "name", {
+        value: "Record",
+        configurable: true,
+    });
 }
+
+define(Record, {
+    isRecord,
+    fromEntries(iterator) {
+        return createRecordFromObject(objectFromEntries(iterator));
+    },
+});
+
 Record.prototype = Object.create(null);
-Record.prototype.constructor = Record;
-Record.prototype.toString = function toString() {
-    return "[record Record]";
-};
-
-Record.isRecord = isRecord;
-
-Record.fromEntries = function fromEntries(iterator) {
-    return createRecordFromObject(objectFromEntries(iterator));
-};
+define(Record.prototype, {
+    constructor: Record,
+    toString() {
+        return "[record Record]";
+    },
+});

--- a/packages/record-tuple-polyfill/src/record.test.js
+++ b/packages/record-tuple-polyfill/src/record.test.js
@@ -131,3 +131,34 @@ test("Records work with Object.values", () => {
 test("Record.prototype.toString", () => {
     expect(Record({ a: 1 }).toString()).toEqual("[record Record]");
 });
+
+describe("correct descriptors", () => {
+    const desc = Object.getOwnPropertyDescriptor;
+
+    test.each(["isRecord", "fromEntries"])("Record.%s", name => {
+        expect(desc(Record, name)).toEqual({
+            writable: true,
+            enumerable: false,
+            configurable: true,
+            value: expect.any(Function),
+        });
+    });
+
+    test("Record.name", () => {
+        expect(desc(Record, "name")).toEqual({
+            writable: false,
+            enumerable: false,
+            configurable: true,
+            value: "Record",
+        });
+    });
+
+    test("Record.length", () => {
+        expect(desc(Record, "name")).toEqual({
+            writable: false,
+            enumerable: false,
+            configurable: true,
+            value: 0,
+        });
+    });
+});

--- a/packages/record-tuple-polyfill/src/record.test.js
+++ b/packages/record-tuple-polyfill/src/record.test.js
@@ -154,11 +154,11 @@ describe("correct descriptors", () => {
     });
 
     test("Record.length", () => {
-        expect(desc(Record, "name")).toEqual({
+        expect(desc(Record, "length")).toEqual({
             writable: false,
             enumerable: false,
             configurable: true,
-            value: 0,
+            value: 1,
         });
     });
 });

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -65,3 +65,14 @@ export function validateProperty(value) {
     }
     return value;
 }
+
+export function define(obj, props) {
+    for (const key of Reflect.ownKeys(props)) {
+        const { get, set, value } = Object.getOwnPropertyDescriptor(props, key);
+        let desc =
+            get || set
+                ? { get, set, configurable: true }
+                : { value, writable: true, configurable: true };
+        Object.defineProperty(obj, key, desc);
+    }
+}


### PR DESCRIPTION
This is https://github.com/bloomberg/record-tuple-polyfill/pull/25. I did something wrong while rebasing and can't reopen that PR anymore.

**Describe your changes**
Fix all the property descriptors to match the spec, as defined at https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects. Note that `.prototype`'s descriptor is still wrong (it should be non-writable), but we can't fix it because it's already non-configurable.

While preparing this PR I noticed another spec compliance bug (`Tuple.prototype[@@iterator]` should be equal to `Tuple.prototype.values`), but I'll fix it in another PR.

**Testing performed**
Added tests for every method's descriptor.