### PR TITLE
Add support for native esmodules to the playground

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
         "plugin:jest/recommended"
     ],
     parserOptions: {
-        ecmaVersion: 2018,
+        ecmaVersion: 2020,
         sourceType: "module",
     },
     rules: {

--- a/packages/record-tuple-playground/src/babel.js
+++ b/packages/record-tuple-playground/src/babel.js
@@ -1,0 +1,35 @@
+import * as Babel from "@babel/core";
+import RecordAndTuple from "@bloomberg/babel-plugin-proposal-record-tuple";
+import PresetEnv from "@babel/preset-env";
+
+export function compile(code, syntaxType, callback) {
+    const options = {
+        presets: [[PresetEnv, { modules: false }]],
+        plugins: [[RecordAndTuple, { syntaxType }], replacePolyfillImport],
+    };
+
+    return Babel.transform(code, options, function(err, result) {
+        callback(err, result ? result.code : undefined);
+    });
+}
+
+const importSource = `data:text/javascript;charset=utf-8,
+export const { Record, Tuple, JSON, stringify, parseImmutable } = globalThis["R&T polyfill"];
+`;
+
+function replacePolyfillImport({ types: t }) {
+    return {
+        visitor: {
+            ImportDeclaration(path) {
+                if (
+                    path.node.source.value ===
+                    "@bloomberg/record-tuple-polyfill"
+                ) {
+                    path.get("source").replaceWith(
+                        t.stringLiteral(importSource),
+                    );
+                }
+            },
+        },
+    };
+}

--- a/packages/record-tuple-playground/src/patch.js
+++ b/packages/record-tuple-playground/src/patch.js
@@ -14,8 +14,6 @@
  ** limitations under the License.
  */
 
-import "./weakref-polyfill";
-import * as Polyfill from "@bloomberg/record-tuple-polyfill";
 import * as Monaco from "monaco-editor";
 import { conf, language } from "./patch-language";
 
@@ -62,15 +60,6 @@ function patch() {
         POLYFILL_DTS,
         "file:///node_modules/@types/@bloomberg/record-tuple-polyfill.d.ts",
     );
-
-    // dirty hack to not require bundling of the output of babel
-    // eslint-disable-next-line no-undef
-    window.require = function(path) {
-        if (path !== "@bloomberg/record-tuple-polyfill") {
-            throw new Error("unexpected");
-        }
-        return Polyfill;
-    };
 }
 
 function patchLanguage() {

--- a/packages/record-tuple-playground/src/runner/index.html
+++ b/packages/record-tuple-playground/src/runner/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+
+    <script src="./index.js"></script>
+</head>
+
+</html>

--- a/packages/record-tuple-playground/src/runner/index.js
+++ b/packages/record-tuple-playground/src/runner/index.js
@@ -1,0 +1,27 @@
+/* globals btoa */
+
+import { POLYFILLED_WEAKREF } from "./weakref-polyfill.js";
+import * as Polyfill from "@bloomberg/record-tuple-polyfill";
+
+globalThis["R&T polyfill"] = Polyfill;
+
+const NO_NATIVE_WEAKREF_ERROR =
+    "WeakMap, WeakRef, and FinalizationRegistry are required for the Record and Tuple playground\n\n" +
+    "We enabled a shim that will leak memory that reproduces those features.\n\n" +
+    "To enable these experimental features natively, go to:\n  https://github.com/bloomberg/record-tuple-polyfill#playground";
+
+globalThis.run = function(source, console) {
+    globalThis.console = console;
+
+    if (POLYFILLED_WEAKREF) {
+        console.error(NO_NATIVE_WEAKREF_ERROR);
+    }
+
+    const encodedJs = btoa(source);
+
+    const dataUri = "data:text/javascript;base64," + encodedJs;
+    return import(/*webpackIgnore: true*/ dataUri).catch(e => {
+        console.error(e.message);
+        console.error(e);
+    });
+};

--- a/packages/record-tuple-playground/src/runner/weakref-polyfill.js
+++ b/packages/record-tuple-playground/src/runner/weakref-polyfill.js
@@ -3,10 +3,10 @@ import {
     WeakRef as WRShim,
     FinalizationGroup as FGShim,
 } from "@ungap/weakrefs";
-if (!window.WeakRef) {
+
+export const POLYFILLED_WEAKREF = !window.WeakRef;
+
+if (POLYFILLED_WEAKREF) {
     window.WeakRef = WRShim;
     window.FinalizationGroup = FGShim;
-    window.POLYFILLED_WEAKREF = true;
 }
-
-// no exports: side effects

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
     context: path.resolve("./packages/record-tuple-playground"),
     entry: {
         index: "./src/index.jsx",
+        "runner/index": "./src/runner/index.js",
         "editor.worker": "monaco-editor/esm/vs/editor/editor.worker.js",
         "ts.worker": "./src/monaco-typescript-rt/ts.worker.js",
     },
@@ -52,7 +53,10 @@ module.exports = {
                     {
                         loader: "file-loader",
                         options: {
-                            name: "[name].[ext]",
+                            context: path.resolve(
+                                "./packages/record-tuple-playground/src",
+                            ),
+                            name: "[path][name].[ext]",
                         },
                     },
                 ],


### PR DESCRIPTION
**Describe your changes**

This PR adds support for ESM to the playground. This makes it easy to load external libraries, such as React.
Since we can't wrap ESM in a function to inject the fake console, I had to sandbox them in an iframe and change the global console inside the iframe.

This PR makes the playground only work in browsers with native modules support: https://github.com/babel/babel/blob/main/packages/babel-compat-data/data/native-modules.json

**Testing performed**
You can try this code in the playground:
```js
console.log(#{ x: 1 });

import React from "https://cdn.skypack.dev/react";

console.log(React);
```

**Additional context**
https://twitter.com/andrewmat/status/1286060991902560257
