### PR TITLE
fix relative path of runner script

### DIFF
--- a/packages/record-tuple-playground/src/runner/index.html
+++ b/packages/record-tuple-playground/src/runner/index.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="utf-8">
 
-    <script src="./runner/index.js"></script>
+    <script src="index.js"></script>
 </head>
 
 </html>


### PR DESCRIPTION
The path of `index.js` should be relative to the `index.html` file.
