### PR TITLE
Fix record sorting to only read keys and not also values

### DIFF
--- a/packages/record-tuple-polyfill/src/record.js
+++ b/packages/record-tuple-polyfill/src/record.js
@@ -46,7 +46,7 @@ function createRecordFromObject(value) {
     // the argument's OwnPropertyKeys internal slot
     // EnumerableOwnPropertyNames - 7.3.22
     const properties = Object.entries(value)
-        .sort(function(a, b) {
+        .sort(function([a], [b]) {
             if (a < b) return -1;
             else if (a > b) return 1;
             return 0;

--- a/packages/record-tuple-polyfill/src/record.test.js
+++ b/packages/record-tuple-polyfill/src/record.test.js
@@ -67,6 +67,8 @@ test("records with the same structural equality will be equal", () => {
     expect(Record({ a: 1 })).toBe(Record({ a: 1 }));
     expect(Record({ a: 1, b: 2 })).toBe(Record({ a: 1, b: 2 }));
     expect(Record({ b: 2, a: 1 })).toBe(Record({ a: 1, b: 2 }));
+    const sym = Symbol("test");
+    expect(Record({ b: sym, a: 1 })).toBe(Record({ a: 1, b: sym }));
     expect(Record({ 0: 0, 1: 1, 2: 2 })).toBe(Record({ 1: 1, 0: 0, 2: 2 }));
     expect(Record({ a: Record({ b: 2 }) })).toBe(
         Record({ a: Record({ b: 2 }) }),


### PR DESCRIPTION
Signed-off-by: Isiah Meadows <contact@isiahmeadows.com>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
Fix the sorting function applied to record entries to only apply to the keys and not also the values

**Testing performed**
I added a test and verified it was broken locally, then introduced the fix.

**Additional context**
