### PR TITLE
Support primitive values in boxes

### DIFF
--- a/packages/record-tuple-polyfill/src/box.test.js
+++ b/packages/record-tuple-polyfill/src/box.test.js
@@ -30,10 +30,16 @@ test("Box creates a Box that wraps a function", () => {
     expect(Box.unbox(box)).toBe(foo);
 });
 
-test("two Boxes wrapping the same value are equal", () => {
+test("two Boxes wrapping the same object are equal", () => {
     const obj = {};
     const box1 = Box(obj);
     const box2 = Box(obj);
+    expect(box1).toBe(box2);
+});
+
+test("two Boxes wrapping the same primitive are equal", () => {
+    const box1 = Box("abc");
+    const box2 = Box("abc");
     expect(box1).toBe(box2);
 });
 

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -54,8 +54,6 @@ export function getTupleLength(value) {
 }
 
 const BOX_TO_VALUE = new WeakMap();
-const OBJECT_TO_BOX = new WeakMap();
-const PRIMITIVE_TO_BOX = new Map();
 
 export function isBox(arg) {
     return BOX_TO_VALUE.has(arg);
@@ -66,12 +64,8 @@ export function unboxBox(box) {
     }
     return BOX_TO_VALUE.get(box);
 }
-export function findBox(value) {
-    return (isPrimitive(value) ? PRIMITIVE_TO_BOX : OBJECT_TO_BOX).get(value);
-}
 export function markBox(box, value) {
     BOX_TO_VALUE.set(box, value);
-    (isPrimitive(value) ? PRIMITIVE_TO_BOX : OBJECT_TO_BOX).set(value, box);
 }
 
 function isRecordOrTuple(value) {


### PR DESCRIPTION
This matches what the proposal currently allows.

There isn't a good way to polyfill boxes of primitives without leaking memory, so I added a warning. Is it ok, or should I remove it?