### PR TITLE
fix: ensure Record.fromEntries throws when provided a Symbol key

### DIFF
--- a/packages/record-tuple-polyfill/src/record.js
+++ b/packages/record-tuple-polyfill/src/record.js
@@ -17,7 +17,7 @@
 import { InternGraph } from "./interngraph";
 import {
     isObject,
-    objectFromEntries,
+    fakeRecordFromEntries,
     validateProperty,
     isRecord,
     markRecord,
@@ -72,7 +72,7 @@ if (Record.name !== "Record") {
 define(Record, {
     isRecord,
     fromEntries(iterator) {
-        return createRecordFromObject(objectFromEntries(iterator));
+        return createRecordFromObject(fakeRecordFromEntries(iterator));
     },
 });
 

--- a/packages/record-tuple-polyfill/src/record.test.js
+++ b/packages/record-tuple-polyfill/src/record.test.js
@@ -125,6 +125,10 @@ test("Record.fromEntries", () => {
             ["a", 1],
         ]),
     ).toThrow();
+
+    let sym = Symbol();
+    expect(() => Record.fromEntries([[sym, 1]])).toThrow();
+    expect(Record.fromEntries([["foo", sym]])).toBe(Record({ foo: sym }));
 });
 test("Records work with Object.values", () => {
     expect(Object.values(Record({ a: 1, b: 2 }))).toEqual([1, 2]);

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -30,8 +30,13 @@ export function isIterableObject(v) {
     return isObject(v) && typeof v[Symbol.iterator] === "function";
 }
 
-export function objectFromEntries(iterable) {
+export function fakeRecordFromEntries(iterable) {
     return [...iterable].reduce((obj, [key, val]) => {
+        if (typeof key === "symbol") {
+            throw new TypeError(
+                "A Symbol cannot be used as a property key in a Record.",
+            );
+        }
         obj[key] = val;
         return obj;
     }, {});


### PR DESCRIPTION
Signed-off-by: Richard Button <rbutton2@bloomberg.net>