### PR TITLE
Tuple.prototype.with handles relative indexes

### DIFF
--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -23,6 +23,7 @@ import {
     getTupleLength,
     define,
     assertFeatures,
+    toIntegerOrInfinity,
 } from "./utils";
 
 function createFreshTupleFromIterableObject(value) {
@@ -204,12 +205,15 @@ define(Tuple.prototype, {
 
     with(index, value) {
         assertTuple(this, "with");
-
-        if (typeof index !== "number")
-            throw new TypeError(`index provided to .with() must be a number`);
-
+        const length = this.length;
+        const relativeIndex = toIntegerOrInfinity(index);
+        const actualIndex =
+            relativeIndex >= 0 ? relativeIndex : length + relativeIndex;
+        if (actualIndex >= length || actualIndex < 0) {
+            throw new RangeError(".with index is out of bounds");
+        }
         const array = Array.from(this);
-        array[index] = value;
+        array[actualIndex] = value;
         return createTupleFromIterableObject(array);
     },
 });

--- a/packages/record-tuple-polyfill/src/tuple.test.js
+++ b/packages/record-tuple-polyfill/src/tuple.test.js
@@ -203,6 +203,13 @@ test("Tuple.prototype.toReversed", () => {
 test("Tuple.prototype.toSpliced", () => {
     expect(Tuple(1, 1, 1, 4).toSpliced(1, 2, 2, 3)).toBe(Tuple(1, 2, 3, 4));
 });
+test("Tuple.prototype.with", () => {
+    expect(() => Tuple().with()).toThrow(RangeError);
+    expect(() => Tuple(1).with(1)).toThrow(RangeError);
+    expect(() => Tuple(1).with(-2)).toThrow(RangeError);
+    expect(Tuple(1, 2, 42).with(2, 3)).toBe(Tuple(1, 2, 3));
+    expect(Tuple(1, 2, 42).with(-1, 3)).toBe(Tuple(1, 2, 3));
+});
 // TODO: Tuple prototype methods
 
 describe("correct descriptors", () => {

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -98,3 +98,22 @@ export function assertFeatures() {
         );
     }
 }
+
+/** https://tc39.es/ecma262/#sec-tointegerorinfinity */
+export function toIntegerOrInfinity(arg) {
+    const n = Number(arg);
+    if (Number.isNaN(n) || n === 0) {
+        return 0;
+    }
+    if (n === Number.POSITIVE_INFINITY) {
+        return Number.POSITIVE_INFINITY;
+    }
+    if (n === Number.NEGATIVE_INFINITY) {
+        return Number.NEGATIVE_INFINITY;
+    }
+    let i = Math.floor(Math.abs(n));
+    if (n < 0) {
+        i = -i;
+    }
+    return i;
+}


### PR DESCRIPTION
**Describe your changes**
Update `Tuple.prototype.with` to match https://tc39.es/proposal-record-tuple/#sec-tuple.prototype.with

- handling negative indexes being relative to `length` 
- coercing the index argument to an integer
- throwing for out of bounds

**Testing performed**
Unit tests added.

