### PR TITLE
make length an own property on tuples

### DIFF
--- a/packages/record-tuple-polyfill/src/tuple.js
+++ b/packages/record-tuple-polyfill/src/tuple.js
@@ -20,7 +20,6 @@ import {
     isTuple,
     markTuple,
     validateProperty,
-    getTupleLength,
     define,
     assertFeatures,
 } from "./utils";
@@ -41,8 +40,12 @@ function createFreshTupleFromIterableObject(value) {
         length++;
     }
 
+    Object.defineProperty(tuple, "length", {
+        value: length,
+    });
+
     Object.freeze(tuple);
-    markTuple(tuple, length);
+    markTuple(tuple);
     return tuple;
 }
 
@@ -106,11 +109,6 @@ Object.defineProperty(Tuple.prototype, Symbol.toStringTag, {
 
 define(Tuple.prototype, {
     constructor: Tuple,
-
-    get length() {
-        assertTuple(this, "length");
-        return getTupleLength(this);
-    },
 
     valueOf() {
         assertTuple(this, "valueOf");

--- a/packages/record-tuple-polyfill/src/tuple.test.js
+++ b/packages/record-tuple-polyfill/src/tuple.test.js
@@ -109,7 +109,7 @@ describe("all and only the specified prototype methods exist", () => {
     const list = ([str]) => str.trim().split(/\s+/g);
 
     const names = list`
-        constructor valueOf length with slice toReversed
+        constructor valueOf with slice toReversed
         toSorted toSpliced concat includes indexOf join
         lastIndexOf entries every filter find findIndex
         flat flatMap forEach keys map reduce reduceRight some
@@ -126,29 +126,22 @@ describe("all and only the specified prototype methods exist", () => {
     });
 });
 
-describe("Tuple.prototype.length", () => {
+describe("Tuple length", () => {
     test("basic behavior", () => {
         expect(Tuple().length).toBe(0);
         expect(Tuple(1, 2, 3).length).toBe(3);
     });
 
-    test("not an own property", () => {
-        expect(hasOwn(Tuple(), "length")).toBe(false);
+    test("is an own property", () => {
+        expect(hasOwn(Tuple(), "length")).toBe(true);
     });
 
-    test("this object", () => {
-        expect(() => Tuple.prototype.length).toThrow(TypeError);
+    test("length descriptor", () => {
+        const lengthDesc = Object.getOwnPropertyDescriptor(Tuple(), "length");
 
-        const length = Object.getOwnPropertyDescriptor(
-            Tuple.prototype,
-            "length",
-        ).get;
-
-        expect(length.call(Tuple(1, 2))).toBe(2);
-
-        expect(() => length()).toThrow(TypeError);
-        expect(() => length.call({})).toThrow(TypeError);
-        expect(() => length.call([])).toThrow();
+        expect(lengthDesc.value).toBe(0);
+        expect(lengthDesc.enumerable).toBe(false);
+        expect(lengthDesc.configurable).toBe(false);
     });
 });
 
@@ -236,7 +229,7 @@ describe("correct descriptors", () => {
     });
 
     const methods = Reflect.ownKeys(Tuple.prototype).filter(
-        n => n !== "length" && n !== Symbol.toStringTag,
+        n => n !== Symbol.toStringTag,
     );
 
     test.each(methods)("Tuple.prototype.%s", name => {
@@ -245,15 +238,6 @@ describe("correct descriptors", () => {
             enumerable: false,
             configurable: true,
             value: expect.any(Function),
-        });
-    });
-
-    test("Tuple.prototype.length", () => {
-        expect(desc(Tuple.prototype, "length")).toEqual({
-            enumerable: false,
-            configurable: true,
-            get: expect.any(Function),
-            set: undefined,
         });
     });
 

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -14,10 +14,7 @@
  ** limitations under the License.
  */
 
-import {
-    originalWeakMapSet,
-    originalWeakSetAdd,
-} from "./weakcollections-original";
+import { originalWeakSetAdd } from "./weakcollections-original";
 
 export function isObject(v) {
     return typeof v === "object" && v !== null;
@@ -43,21 +40,18 @@ export function fakeRecordFromEntries(iterable) {
 }
 
 const RECORD_WEAKSET = new WeakSet();
-const TUPLE_WEAKMAP = new WeakMap(); // tuple -> length
+const TUPLE_WEAKSET = new WeakSet();
 export function isRecord(value) {
     return RECORD_WEAKSET.has(value);
 }
 export function isTuple(value) {
-    return TUPLE_WEAKMAP.has(value);
+    return TUPLE_WEAKSET.has(value);
 }
 export function markRecord(value) {
     originalWeakSetAdd.call(RECORD_WEAKSET, value);
 }
-export function markTuple(value, length) {
-    originalWeakMapSet.call(TUPLE_WEAKMAP, value, length);
-}
-export function getTupleLength(value) {
-    return TUPLE_WEAKMAP.get(value);
+export function markTuple(value) {
+    originalWeakSetAdd.call(TUPLE_WEAKSET, value);
 }
 
 function isRecordOrTuple(value) {


### PR DESCRIPTION
replaces #87 

---

**Describe your changes**
`"length"` is now an own property on tuples, rather than a prototype getter. As per https://github.com/tc39/proposal-record-tuple/pull/310

**Testing performed**
Unit tests updated.
