### PR TITLE
Can no longer create records with symbol keys

### DIFF
--- a/packages/record-tuple-polyfill/src/record.js
+++ b/packages/record-tuple-polyfill/src/record.js
@@ -18,6 +18,7 @@ import { InternGraph } from "./interngraph";
 import {
     isObject,
     fakeRecordFromEntries,
+    validateKey,
     validateProperty,
     isRecord,
     markRecord,
@@ -46,14 +47,17 @@ function createRecordFromObject(value) {
     // sort all property names by the order specified by
     // the argument's OwnPropertyKeys internal slot
     // EnumerableOwnPropertyNames - 7.3.22
-    const properties = Object.entries(value)
+    const properties = Reflect.ownKeys(value)
+        .flatMap(k => {
+            const desc = Object.getOwnPropertyDescriptor(value, k);
+            if (!desc.enumerable) return [];
+            return [[validateKey(k), validateProperty(value[k])]];
+        })
         .sort(function([a], [b]) {
             if (a < b) return -1;
             else if (a > b) return 1;
             return 0;
-        })
-        .map(([name, value]) => [name, validateProperty(value)]);
-
+        });
     return RECORD_GRAPH.get(properties);
 }
 

--- a/packages/record-tuple-polyfill/src/utils.js
+++ b/packages/record-tuple-polyfill/src/utils.js
@@ -28,15 +28,11 @@ export function isIterableObject(v) {
 }
 
 export function fakeRecordFromEntries(iterable) {
-    return [...iterable].reduce((obj, [key, val]) => {
-        if (typeof key === "symbol") {
-            throw new TypeError(
-                "A Symbol cannot be used as a property key in a Record.",
-            );
-        }
-        obj[key] = val;
-        return obj;
-    }, {});
+    const retVal = Object.create(null);
+    for (const [key, value] of iterable) {
+        retVal[validateKey(key)] = validateProperty(value);
+    }
+    return retVal;
 }
 
 const RECORD_WEAKSET = new WeakSet();
@@ -57,13 +53,23 @@ export function markTuple(value) {
 function isRecordOrTuple(value) {
     return isRecord(value) || isTuple(value);
 }
+
+export function validateKey(key) {
+    if (typeof key === "symbol") {
+        throw new TypeError(
+            "A Symbol cannot be used as a property key in a Record.",
+        );
+    }
+    return String(key);
+}
+
 export function validateProperty(value) {
     if (isObject(value) && !isRecordOrTuple(value)) {
-        throw new Error(
+        throw new TypeError(
             "TypeError: cannot use an object as a value in a record",
         );
     } else if (isFunction(value)) {
-        throw new Error(
+        throw new TypeError(
             "TypeError: cannot use a function as a value in a record",
         );
     }


### PR DESCRIPTION

**Describe your changes**
- Prevents being able to create records with symbol keys. Fixes #77
- Increases spec compliance of `Record.fromEntries` by validating the iterator entry by entry

**Testing performed**
Adds unit tests

